### PR TITLE
add github authentication

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,10 +1,19 @@
+import { auth } from '@/lib/auth';
 import { SigninView } from '@/modules/auth/ui/views/signin-view'
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 import React from 'react'
 
+const SigninPage = async () => {
 
-console.log('signin page from auth')
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  })
 
-const SigninPage = () => {
+  if (!!session) {
+    redirect('/');
+  }
+
   return (
     <SigninView />
   )

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,11 +1,19 @@
-"use client"
-
+import { auth } from '@/lib/auth'
 import { SignupView } from '@/modules/auth/ui/views/signup-view'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
 import React from 'react'
 
-console.log('signup page')
+const SignupPage = async () => {
 
-const SignupPage = () => {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    })
+
+    if (!!session) {
+        redirect('/');
+    }
+
     return (
         <SignupView />
     )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,43 +1,21 @@
-'use client'
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
+import { HomeView } from '@/modules/home/ui/views/home-view';
 
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { useState } from 'react';
-import { authClient } from '@/lib/auth-client';
+const HomePage = async () => {
 
-export default function Home() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  })
 
-  const { data: session } = authClient.useSession()
-
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
-  if (session) {
-    return <div>
-      <p>Signed in as {session.user?.name}</p>
-      <Button onClick={() => authClient.signOut()}>Sign out</Button>
-    </div>
-  }
-
-  const onSubit = () => {
-    authClient.signUp.email({
-      name,
-      email,
-      password
-    }, {
-      onError: () => alert("Error signing up"),
-      onSuccess: () => alert("Signed up successfully")
-    })
+  if (!session) {
+    redirect('/signin');
   }
 
   return (
-    <div>
-      <Input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
-      <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-      <Input placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
-
-      <Button onClick={onSubit}>Sign up</Button>
-    </div>
-  );
+    <HomeView />
+  )
 }
+
+export default HomePage

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,12 @@ export const auth = betterAuth({
     emailAndPassword: {
         enabled: true,
     },
+    socialProviders: {
+        github: {
+            clientId: process.env.GITHUB_CLIENT_ID as string,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+        },
+    },
     database: drizzleAdapter(db, {
         provider: "pg", // or "mysql", "sqlite"
         schema: { ...schema },

--- a/src/modules/auth/ui/views/signin-view.tsx
+++ b/src/modules/auth/ui/views/signin-view.tsx
@@ -7,13 +7,12 @@ import { Button } from "@/components/ui/button"
 import { useForm } from "react-hook-form"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { OctagonAlertIcon } from "lucide-react"
+import { Github, OctagonAlertIcon } from "lucide-react"
 import { Alert, AlertTitle } from "@/components/ui/alert"
 import Link from "next/link"
 import { useState } from "react"
 
 import { authClient } from "@/lib/auth-client"
-import { useRouter } from "next/navigation"
 
 const formSchema = z.object({
     email: z.string().email({ message: "Invalid email address." }),
@@ -22,7 +21,6 @@ const formSchema = z.object({
 
 export const SigninView = () => {
 
-    const router = useRouter();
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
 
@@ -41,12 +39,11 @@ export const SigninView = () => {
         authClient.signIn.email({
             email: values.email,
             password: values.password,
+            callbackURL: "/"
         },
             {
                 onSuccess: () => {
                     setLoading(false);
-                    router.push("/");
-
                 },
                 onError: ({ error }) => {
                     setLoading(false);
@@ -110,10 +107,18 @@ export const SigninView = () => {
 
                                 <div className="flex items-center text-sm text-gray-800 before:flex-1 before:border-t before:border-gray-200 before:me-6 after:flex-1 after:border-t after:border-gray-200 after:ms-6 dark:text-white dark:before:border-neutral-600 dark:after:border-neutral-600">Or continue with</div>
 
-                                <div className="grid grid-cols-2 gap-4">
-                                    <Button type="button" variant="outline" disabled={loading}>Github</Button>
-                                    <Button type="button" variant="outline" disabled={loading}>Google</Button>
-                                </div>
+                                <div className="grid grid-cols-1 gap-4">
+                                    <Button type="button" variant="outline" disabled={loading}
+                                        onClick={() => {
+                                            authClient.signIn.social({ provider: "github" });
+                                        }}
+                                    ><Github /> Github</Button>
+                                    {/*     Implement Google Auth later
+                                <Button type="button" variant="outline" disabled={loading}
+                                        onClick={() => {
+                                            authClient.signIn.social({ provider: "google" });
+                                        }}
+                                    >Google</Button> */}                                </div>
                                 <div>
                                     Don&apos;t have an account? <Link href="/signup" className="text-primary underline underline-offset-3">Register</Link>
                                 </div>

--- a/src/modules/auth/ui/views/signup-view.tsx
+++ b/src/modules/auth/ui/views/signup-view.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { useForm } from "react-hook-form"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { OctagonAlertIcon } from "lucide-react"
+import { Github, OctagonAlertIcon } from "lucide-react"
 import { Alert, AlertTitle } from "@/components/ui/alert"
 import Link from "next/link"
 import { useState } from "react"
@@ -27,9 +27,10 @@ const formSchema = z.object({
 
 export const SignupView = () => {
 
-    const router = useRouter();
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
+
+    const router = useRouter();
 
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
@@ -49,12 +50,12 @@ export const SignupView = () => {
             name: values.name,
             email: values.email,
             password: values.password,
+            callbackURL: "/"
         },
             {
                 onSuccess: () => {
                     setLoading(false);
                     router.push("/");
-
                 },
                 onError: ({ error }) => {
                     setLoading(false);
@@ -146,14 +147,37 @@ export const SignupView = () => {
                                     </Alert>
                                 )}
                                 <Button type="submit" disabled={loading}>
-                                    {loading ? "Logging in..." : "Login"}
+                                    {loading ? "Signing up..." : "Sign up"}
                                 </Button>
 
                                 <div className="flex items-center text-sm text-gray-800 before:flex-1 before:border-t before:border-gray-200 before:me-6 after:flex-1 after:border-t after:border-gray-200 after:ms-6 dark:text-white dark:before:border-neutral-600 dark:after:border-neutral-600">Or continue with</div>
 
-                                <div className="grid grid-cols-2 gap-4">
-                                    <Button type="button" variant="outline" disabled={loading}>Github</Button>
-                                    <Button type="button" variant="outline" disabled={loading}>Google</Button>
+                                <div className="grid grid-cols-1">
+                                    <Button type="button" variant="outline" disabled={loading}
+                                        onClick={() => {
+                                            authClient.signIn.social(
+                                                {
+                                                    provider: "github",
+                                                    callbackURL: "/"
+                                                },
+                                                {
+                                                    onSuccess: () => {
+                                                        setLoading(false);
+                                                    },
+                                                    onError: ({ error }) => {
+                                                        setLoading(false);
+                                                        setError(error.message)
+                                                    }
+                                                }
+                                            );
+                                        }}
+                                    ><Github /> Github</Button>
+                                    {/*     Implement Google Auth later
+                                <Button type="button" variant="outline" disabled={loading}
+                                        onClick={() => {
+                                            authClient.signIn.social({ provider: "google" });
+                                        }}
+                                    >Google</Button> */}
                                 </div>
                                 <div>
                                     Already have an account? <Link href="/signin" className="text-primary underline underline-offset-3">Sign in</Link>

--- a/src/modules/home/ui/views/home-view.tsx
+++ b/src/modules/home/ui/views/home-view.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { Button } from '@/components/ui/button';
+
+import { authClient } from '@/lib/auth-client';
+import { useRouter } from 'next/navigation';
+
+export const HomeView = () => {
+
+    const { data: session } = authClient.useSession()
+
+    const router = useRouter();
+
+    if (!session) {
+        return <div>
+            Loading...
+        </div>
+    }
+
+    return <div>
+        <p>Signed in as {session.user?.name}</p>
+        <Button onClick={() =>
+            authClient.signOut({
+                fetchOptions: {
+                    onSuccess: () => router.push('/signin'),
+                }
+            })}
+        >Sign out</Button>
+    </div>
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GitHub sign-in on Sign in and Sign up screens.
  - Introduced a new Home view that shows the signed-in user and provides a Sign out action (returns to Sign in).
  - Email sign-in/sign-up now redirect to Home after success.
  - Consolidated social login to GitHub; Google option temporarily unavailable.

- Refactor
  - Converted Sign in, Sign up, and Home pages to server-rendered with session-aware redirects (signed-in users bypass auth; unauthenticated users are sent to Sign in).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->